### PR TITLE
updated pre-commit hook and read me file

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
 yarn format
 yarn generate:test-catalogue
-git add test-catalogue/*.md

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The following Markdown files contain an up-to-date list of all test scenarios an
 
 > These catalogues are automatically generated whenever new tests are added or existing tests are modified.
 > Note: These files are automatically updated on every commit via a pre-commit hook.
+> Once files have been updated / generated, verify contents and stage the changes to be added to PR. 
 > Run `yarn generate:test-catalogue` to update them manually if needed.
 
 ## Features
@@ -83,12 +84,10 @@ Dev
 ```bash
 yarn load-secrets:dev
 ```
-
 Staging
 ```bash
 yarn load-secrets:stg
 ```
-
 Demo
 ```bash
 yarn load-secrets:demo


### PR DESCRIPTION
### Change description

- Updated pre-commit hook to remove need for adding updated test catalogue files directly to commit
- Test catalogue files will continue to be generated automatically via script during commit but will need to be staged after they have been verified. 

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
