### PR TITLE
S28-4336 Fix failing accessibility for view live recordings

### DIFF
--- a/playwright-e2e/utils/accessibility.utils.ts
+++ b/playwright-e2e/utils/accessibility.utils.ts
@@ -1,9 +1,0 @@
-import axe from 'axe-core';
-
-export async function runAxeAuditIgnoringRules(page, ignoreRules: string[] = []) {
-  const axePath = require.resolve('axe-core/axe.min.js');
-  await page.addScriptTag({ path: axePath });
-
-  const results = await page.evaluate(async () => axe.run());
-  return results.violations.filter((v) => !ignoreRules.includes(v.id));
-}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/S28-4336

### Change description
Fixes a failing test for view live recordings.

The axe violation that it is failing on ("Scrollable region must have keyboard access") is not currently fixable within Power Apps due to the way that the html is auto-generated. Ignore that violation for now

Image showing the test now passing:

<img width="1006" height="601" alt="image" src="https://github.com/user-attachments/assets/e2b977c3-4984-4aa3-aad8-8101d112c010" />
