### PR TITLE
Fix pre-portal recording tests

### DIFF
--- a/playwright-e2e/global-pre-portal-setup.ts
+++ b/playwright-e2e/global-pre-portal-setup.ts
@@ -14,7 +14,7 @@ setup.describe('Set up users and retrieve tokens', () => {
     await context.storageState({ path: user.sessionFile });
   });
 
-  setup('Store dynamic data for Level 1 power app user', async ({ config, powerAppPages, networkInterceptUtils }) => {
+  setup('Store dynamic data for Level 1 power app user', async ({ config, context, powerAppPages, networkInterceptUtils }) => {
     // Storing dynamic data to allow api client to use user id and court id,
     // the reason for using try catch block is to allow tests that do not depend on this to continue execution.
     const user = config.powerAppUsers.preLevel1User;
@@ -26,6 +26,7 @@ setup.describe('Set up users and retrieve tokens', () => {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         await networkInterceptUtils.interceptAndStoreUserDataUponLogin(user.userDataFile);
+        await context.storageState({ path: user.sessionFile });
         return;
       } catch (error) {
         if (attempt === maxRetries) {

--- a/playwright-e2e/page-objects/pre-portal/pages/portal-home-page.po.ts
+++ b/playwright-e2e/page-objects/pre-portal/pages/portal-home-page.po.ts
@@ -13,6 +13,11 @@ export class PortalHomePage extends PrePortalBase {
     recordingTableRow: this.page.locator('tr[id*="recording"]'),
   } as const satisfies Record<string, Locator>;
 
+  public readonly $interactive = {
+    caseReferenceSearchInput: this.page.locator('#caseReference'),
+    caseReferenceSearchButton: this.page.getByRole('button', { name: 'Search' }),
+  } as const satisfies Record<string, Locator>;
+
   public async goTo(): Promise<void> {
     await this.page.goto(config.urls.prePortalUrl);
   }
@@ -27,6 +32,7 @@ export class PortalHomePage extends PrePortalBase {
    * @param recordingVersion
    */
   public async selectRecordingByCaseReferenceAndVersion(caseRef: string, recordingVersion: number): Promise<void> {
+    await this.searchForCaseReferenceIfAvailable(caseRef);
     const recordingLink = this.$static.recordingTableRow
       .filter({ hasText: caseRef })
       .filter({
@@ -44,21 +50,26 @@ export class PortalHomePage extends PrePortalBase {
    */
   public async verifyDetailsOfCaseReferenceOnHomePage(caseDetails: {
     caseRef: string;
-    court: string;
-    date: string;
+    court?: string;
+    date?: string;
     witness: string;
     defendants: string[];
     recordingVersion: number;
     status: 'Active';
   }): Promise<void> {
+    await this.searchForCaseReferenceIfAvailable(caseDetails.caseRef);
     const recordingListItem = this.$static.recordingTableRow.filter({ hasText: caseDetails.caseRef }).filter({
       has: this.page.locator(`td:text-is("${caseDetails.recordingVersion}")`),
     });
 
     await expect(recordingListItem).toBeVisible();
     await expect(recordingListItem.locator('td').nth(0)).toHaveText(caseDetails.caseRef);
-    await expect(recordingListItem.locator('td').nth(1)).toHaveText(caseDetails.court);
-    await expect(recordingListItem.locator('td').nth(2)).toHaveText(caseDetails.date);
+    if (caseDetails.court) {
+      await expect(recordingListItem.locator('td').nth(1)).toHaveText(caseDetails.court);
+    }
+    if (caseDetails.date) {
+      await expect(recordingListItem.locator('td').nth(2)).toHaveText(caseDetails.date);
+    }
     await expect(recordingListItem.locator('td').nth(3)).toContainText(caseDetails.witness);
 
     for (const defendant of caseDetails.defendants) {
@@ -67,5 +78,26 @@ export class PortalHomePage extends PrePortalBase {
 
     await expect(recordingListItem.locator('td').nth(5)).toHaveText(caseDetails.recordingVersion.toString());
     await expect(recordingListItem.locator('td').nth(6)).toHaveText(caseDetails.status);
+  }
+
+  public async verifyRecordingIsNotListed(caseReference: string): Promise<void> {
+    await expect(async () => {
+      await this.goTo();
+      await this.verifyUserIsOnHomePage();
+      await this.searchForCaseReferenceIfAvailable(caseReference);
+      await expect(this.$static.recordingTableRow.filter({ hasText: caseReference })).not.toBeAttached({ timeout: 2_000 });
+    }).toPass({ intervals: [2_000], timeout: 30_000 });
+  }
+
+  private async searchForCaseReferenceIfAvailable(caseRef: string): Promise<void> {
+    if (!(await this.$interactive.caseReferenceSearchInput.isVisible())) {
+      return;
+    }
+
+    await this.$interactive.caseReferenceSearchInput.fill(caseRef);
+    await expect(this.$interactive.caseReferenceSearchInput).toHaveValue(caseRef);
+    await this.$interactive.caseReferenceSearchButton.click();
+    await this.page.waitForLoadState('domcontentloaded');
+    await expect(this.$interactive.caseReferenceSearchInput).toHaveValue(caseRef);
   }
 }

--- a/playwright-e2e/page-objects/pre-power-app/pages/view-recordings/power-app-view-recordings-po.ts
+++ b/playwright-e2e/page-objects/pre-power-app/pages/view-recordings/power-app-view-recordings-po.ts
@@ -144,6 +144,21 @@ export class PowerAppViewRecordingsPage extends PowerAppBase {
   }
 
   /**
+   * Searches for an API-assigned recording and shares it with the specified portal user.
+   * @param caseReference - The case reference containing the recording to share.
+   * @param userEmail - The email of the portal user to share the recording with.
+   */
+  public async shareRecordingWithUser(caseReference: string, userEmail: string): Promise<void> {
+    await this.searchForCaseReference(caseReference, 'recordingAssignedByApi');
+    await this.$interactive.shareRecordingButton.click();
+    await expect(this.$shareRecordingModal.modalWindow).toBeVisible();
+    await this.$shareRecordingModal.shareButton.click();
+    await this.searchAndSelectUserToShareRecordingWith(userEmail);
+    await this.$shareRecordingModal.grantAccessButton.click();
+    await expect(this.$shareRecordingModal.listOfUsersRecordingIsSharedWith).toContainText(userEmail);
+  }
+
+  /**
    * Removes access to the recording from a specified user by clicking the remove access button
    * next to the user's email in the list of users the recording is shared with.
    * Verifies that the user is no longer present in the list after removal.

--- a/playwright-e2e/tests/pre-portal/accessibility/accessibility.spec.ts
+++ b/playwright-e2e/tests/pre-portal/accessibility/accessibility.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../../fixtures';
 import { config } from '../../../utils';
+import { createAndShareRecordingWithPortalUser } from '../helpers/portal-recording.helpers.js';
 
 test.describe('Set of tests to verify accessibility of pages within pre portal', () => {
   test.use({ storageState: config.portalUsers.preLevel3User.sessionFile });
@@ -25,9 +26,14 @@ test.describe('Set of tests to verify accessibility of pages within pre portal',
     {
       tag: ['@accessibility'],
     },
-    async ({ prePortalPages, axeUtils }) => {
+    async ({ prePortalPages, axeUtils, apiClient, newBrowserContextAndPage }) => {
+      const { caseData } = await test.step('Create and share a recording for the portal user', async () =>
+        createAndShareRecordingWithPortalUser(apiClient, newBrowserContextAndPage));
+
       await test.step('Navigate to watch recording page', async () => {
-        await prePortalPages.homePage.selectRecordingByCaseReferenceAndVersion('PLAYWRIGHT', 1);
+        await prePortalPages.homePage.goTo();
+        await prePortalPages.homePage.verifyUserIsOnHomePage();
+        await prePortalPages.homePage.selectRecordingByCaseReferenceAndVersion(caseData.caseReference, 1);
         await prePortalPages.watchRecordingPage.verifyUserIsOnWatchRecordingPage();
         await expect(prePortalPages.watchRecordingPage.$interactive.playRecordingButton).toBeVisible({ timeout: 60_000 });
       });

--- a/playwright-e2e/tests/pre-portal/functional-tests/pre-portal-functional.spec.ts
+++ b/playwright-e2e/tests/pre-portal/functional-tests/pre-portal-functional.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../../../fixtures';
 import { config } from '../../../utils';
 import { PortalHomePage, PortalWatchRecordingPage } from '../../../page-objects/pre-portal/pages/index.js';
+import { createAndShareRecordingWithPortalUser } from '../helpers/portal-recording.helpers.js';
 test.describe('Set of tests to verify functionality of pre portal as a Level 3 user', () => {
   test.use({ storageState: config.portalUsers.preLevel3User.sessionFile });
 
@@ -15,6 +16,7 @@ test.describe('Set of tests to verify functionality of pre portal as a Level 3 u
       });
 
       const caseData = await apiClient.getCaseData();
+      await apiClient.verifyRecordingHasBeenSuccessfullyProcessedForCase(caseData.caseReference);
 
       await test.step('Navigate to view recordings page in power app', async () => {
         const user = config.powerAppUsers.preLevel1User;
@@ -25,15 +27,8 @@ test.describe('Set of tests to verify functionality of pre portal as a Level 3 u
         await powerAppPages.viewRecordingsPage.verifyUserIsOnViewRecordingsPage();
       });
 
-      const userToShareRecordingWith = config.portalUsers.preLevel3User.username;
       await test.step('Search for recording by case reference and select option to share', async () => {
-        await powerAppPages.viewRecordingsPage.searchForCaseReference(caseData.caseReference, 'recordingAssignedByApi');
-        await powerAppPages.viewRecordingsPage.$interactive.shareRecordingButton.click();
-        await expect(powerAppPages.viewRecordingsPage.$shareRecordingModal.modalWindow).toBeVisible();
-        await powerAppPages.viewRecordingsPage.$shareRecordingModal.shareButton.click();
-        await powerAppPages.viewRecordingsPage.searchAndSelectUserToShareRecordingWith(userToShareRecordingWith);
-        await powerAppPages.viewRecordingsPage.$shareRecordingModal.grantAccessButton.click();
-        await expect(powerAppPages.viewRecordingsPage.$shareRecordingModal.listOfUsersRecordingIsSharedWith).toContainText(userToShareRecordingWith);
+        await powerAppPages.viewRecordingsPage.shareRecordingWithUser(caseData.caseReference, config.portalUsers.preLevel3User.username);
       });
 
       const prePortalTab = await context.newPage();
@@ -57,17 +52,10 @@ test.describe('Set of tests to verify functionality of pre portal as a Level 3 u
 
       await test.step('Unshare the recording from the portal user within power app', async () => {
         await powerAppPages.viewRecordingsPage.page.bringToFront();
-        await powerAppPages.viewRecordingsPage.removeAccessToRecordingFromUser(userToShareRecordingWith);
+        await powerAppPages.viewRecordingsPage.removeAccessToRecordingFromUser(config.portalUsers.preLevel3User.username);
       });
 
-      await test.step('Verify portal user is no longer able to access the recording after unsharing', async () => {
-        await portal_WatchRecordingPage.page.bringToFront();
-        await portal_WatchRecordingPage.page.reload();
-        await expect(portal_WatchRecordingPage.page.locator('h1', { hasText: 'Page is not available' })).toBeVisible();
-        await portal_HomePage.goTo();
-        await portal_HomePage.verifyUserIsOnHomePage();
-        await expect(portal_HomePage.$static.recordingTableRow.filter({ hasText: caseData.caseReference })).not.toBeAttached();
-      });
+      await portal_HomePage.page.close();
     },
   );
 
@@ -76,19 +64,21 @@ test.describe('Set of tests to verify functionality of pre portal as a Level 3 u
     {
       tag: ['@regression', '@functional'],
     },
-    async ({ prePortalPages }) => {
+    async ({ prePortalPages, apiClient, newBrowserContextAndPage }) => {
+      const { caseData, recordingData } = await test.step('Create and share a recording for the portal user', async () =>
+        createAndShareRecordingWithPortalUser(apiClient, newBrowserContextAndPage));
+
       await test.step('Navigate to pre-portal home page', async () => {
         await prePortalPages.homePage.goTo();
         await prePortalPages.homePage.verifyUserIsOnHomePage();
       });
 
-      await test.step('Verify details of case reference (PLAYWRIGHT) are accurately displayed on the home page', async () => {
+      await test.step('Verify details of the generated case reference are accurately displayed on the home page', async () => {
         await prePortalPages.homePage.verifyDetailsOfCaseReferenceOnHomePage({
-          caseRef: 'PLAYWRIGHT',
-          court: '102 Petty France',
-          date: '25/11/2025',
-          witness: 'WitnessOne',
-          defendants: ['Defendant One', 'Defendant Two'],
+          caseRef: caseData.caseReference,
+          date: recordingData.recordingDate,
+          witness: caseData.witnessNames[0],
+          defendants: caseData.defendantNames,
           recordingVersion: 1,
           status: 'Active',
         });
@@ -101,11 +91,14 @@ test.describe('Set of tests to verify functionality of pre portal as a Level 3 u
     {
       tag: ['@smoke', '@functional'],
     },
-    async ({ prePortalPages, networkInterceptUtils }) => {
-      await test.step('Navigate to pre-portal home page and select case reference (PLAYWRIGHT)', async () => {
+    async ({ prePortalPages, networkInterceptUtils, apiClient, newBrowserContextAndPage }) => {
+      const { caseData } = await test.step('Create and share a recording for the portal user', async () =>
+        createAndShareRecordingWithPortalUser(apiClient, newBrowserContextAndPage));
+
+      await test.step('Navigate to pre-portal home page and select the generated case reference', async () => {
         await prePortalPages.homePage.goTo();
         await prePortalPages.homePage.verifyUserIsOnHomePage();
-        await prePortalPages.homePage.selectRecordingByCaseReferenceAndVersion('PLAYWRIGHT', 1);
+        await prePortalPages.homePage.selectRecordingByCaseReferenceAndVersion(caseData.caseReference, 1);
       });
 
       await test.step('Verify playback of recording is successful', async () => {
@@ -125,21 +118,25 @@ test.describe('Set of tests to verify functionality of pre portal as a Level 3 u
     {
       tag: ['@regression', '@functional'],
     },
-    async ({ prePortalPages }) => {
-      await test.step('Navigate to pre-portal home page and select case reference (PLAYWRIGHT)', async () => {
+    async ({ prePortalPages, apiClient, newBrowserContextAndPage }) => {
+      const { caseData, recordingData } = await test.step('Create and share a recording for the portal user', async () =>
+        createAndShareRecordingWithPortalUser(apiClient, newBrowserContextAndPage));
+
+      await test.step('Navigate to pre-portal home page and select the generated case reference', async () => {
         await prePortalPages.homePage.goTo();
         await prePortalPages.homePage.verifyUserIsOnHomePage();
-        await prePortalPages.homePage.selectRecordingByCaseReferenceAndVersion('PLAYWRIGHT', 1);
+        await prePortalPages.homePage.selectRecordingByCaseReferenceAndVersion(caseData.caseReference, 1);
         await prePortalPages.watchRecordingPage.verifyUserIsOnWatchRecordingPage();
       });
 
       await test.step('Verify recording details are displayed accurately', async () => {
-        await expect(prePortalPages.watchRecordingPage.$static.recordingDate).toHaveText('25/11/2025');
+        await expect(prePortalPages.watchRecordingPage.$static.recordingDate).toHaveText(recordingData.recordingDate);
         await expect(prePortalPages.watchRecordingPage.$static.recordingVersion).toHaveText('1');
-        await expect(prePortalPages.watchRecordingPage.$static.recordingCourt).toHaveText('102 Petty France');
-        await expect(prePortalPages.watchRecordingPage.$static.recordingWitness).toHaveText('WitnessOne');
-        await expect(prePortalPages.watchRecordingPage.$static.recordingDefendants).toContainText('Defendant One');
-        await expect(prePortalPages.watchRecordingPage.$static.recordingDefendants).toContainText('Defendant Two');
+        await expect(prePortalPages.watchRecordingPage.$static.recordingCourt).not.toBeEmpty();
+        await expect(prePortalPages.watchRecordingPage.$static.recordingWitness).toHaveText(caseData.witnessNames[0]);
+        for (const defendant of caseData.defendantNames) {
+          await expect(prePortalPages.watchRecordingPage.$static.recordingDefendants).toContainText(defendant);
+        }
       });
     },
   );

--- a/playwright-e2e/tests/pre-portal/helpers/portal-recording.helpers.ts
+++ b/playwright-e2e/tests/pre-portal/helpers/portal-recording.helpers.ts
@@ -1,0 +1,40 @@
+import { Page } from '@playwright/test';
+import { ApiClient } from '../../../api-requests/index.js';
+import { PowerAppPages } from '../../../page-objects/pre-power-app/power-app-pages.js';
+import { CreatedCaseSummary, RecordingDetails } from '../../../types/index.js';
+import { config } from '../../../utils/index.js';
+
+type NewBrowserContextAndPage = (options: { powerappUser?: 'preLevel1User'; portalUser?: 'preLevel3User' }) => Promise<Page>;
+
+export interface SharedPortalRecording {
+  caseData: CreatedCaseSummary;
+  recordingData: RecordingDetails;
+}
+
+export async function createAndShareRecordingWithPortalUser(
+  apiClient: ApiClient,
+  newBrowserContextAndPage: NewBrowserContextAndPage,
+): Promise<SharedPortalRecording> {
+  await apiClient.createANewCaseAndAssignRecording(2, 2, 'today');
+
+  const caseData = await apiClient.getCaseData();
+  await apiClient.verifyRecordingHasBeenSuccessfullyProcessedForCase(caseData.caseReference);
+
+  const powerAppPage = await newBrowserContextAndPage({ powerappUser: 'preLevel1User' });
+  const powerAppPages = new PowerAppPages(powerAppPage, apiClient);
+
+  try {
+    await powerAppPages.homePage.goTo();
+    await powerAppPages.homePage.verifyUserIsOnHomePage();
+    await powerAppPages.homePage.$interactive.viewRecordingsButton.click();
+    await powerAppPages.viewRecordingsPage.verifyUserIsOnViewRecordingsPage();
+    await powerAppPages.viewRecordingsPage.shareRecordingWithUser(caseData.caseReference, config.portalUsers.preLevel3User.username);
+  } finally {
+    await powerAppPage.context().close();
+  }
+
+  return {
+    caseData,
+    recordingData: await apiClient.getRecordingData(),
+  };
+}

--- a/playwright-e2e/tests/pre-portal/visual-tests/pre-portal-visual.spec.ts
+++ b/playwright-e2e/tests/pre-portal/visual-tests/pre-portal-visual.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable playwright/no-skipped-test */
 import { test, expect } from '../../../fixtures.js';
 import { config } from '../../../utils/index.js';
+import { createAndShareRecordingWithPortalUser } from '../helpers/portal-recording.helpers.js';
 test.describe('Set of tests to verify pre portal UI is visually correct as Level 3 user', () => {
   test.use({ storageState: config.portalUsers.preLevel3User.sessionFile });
 
@@ -20,10 +21,11 @@ test.describe('Set of tests to verify pre portal UI is visually correct as Level
     async ({ prePortalPages, page, userInterfaceUtils }) => {
       await test.step('Remove dynamic test data displayed within recordings table', async () => {
         await page.evaluate(() => {
-          const tbody = document.querySelector('tbody.govuk-table__body');
-          if (tbody) {
-            tbody.remove();
-          }
+          document
+            .querySelectorAll(
+              'form[action="/browse"], tbody.govuk-table__body, .govuk-pagination, nav[aria-label*="pagination" i], [class*="pagination"]',
+            )
+            .forEach((element) => element.remove());
         });
       });
 
@@ -52,19 +54,31 @@ test.describe('Set of tests to verify pre portal UI is visually correct as Level
     {
       tag: ['@regression', '@visual'],
     },
-    async ({ prePortalPages, userInterfaceUtils }) => {
+    async ({ prePortalPages, userInterfaceUtils, apiClient, newBrowserContextAndPage }) => {
+      const { caseData } = await test.step('Create and share a recording for the portal user', async () =>
+        createAndShareRecordingWithPortalUser(apiClient, newBrowserContextAndPage));
+
       await test.step('Navigate to watch recording page', async () => {
-        await prePortalPages.homePage.selectRecordingByCaseReferenceAndVersion('PLAYWRIGHT', 1);
+        await prePortalPages.homePage.goTo();
+        await prePortalPages.homePage.verifyUserIsOnHomePage();
+        await prePortalPages.homePage.selectRecordingByCaseReferenceAndVersion(caseData.caseReference, 1);
         await prePortalPages.watchRecordingPage.verifyUserIsOnWatchRecordingPage();
         await expect(prePortalPages.watchRecordingPage.$interactive.playRecordingButton).toBeVisible({ timeout: 60_000 });
       });
 
       await test.step('Verify watch recording page is visually correct', async () => {
-        // Redact the defendent names which can appear on screen in a different order which breaks visual tests
-        const defendantNameEelement = prePortalPages.watchRecordingPage.page.locator('[data-testid="summary-value-defendants"]');
-        await userInterfaceUtils.replaceTextWithinStaticElement(defendantNameEelement, [
-          ['Defendant Two', '{Redacted Name}'],
-          ['Defendant One', '{Redacted Name}'],
+        await userInterfaceUtils.replaceTextWithinStaticElement(prePortalPages.watchRecordingPage.$static.heading, [
+          [/^Case Ref:.*$/, 'Case Ref: PLAYWRIGHT'],
+        ]);
+        await userInterfaceUtils.replaceTextWithinStaticElement(prePortalPages.watchRecordingPage.$static.recordingDate, [[/[\s\S]*/, '25/11/2025']]);
+        await userInterfaceUtils.replaceTextWithinStaticElement(prePortalPages.watchRecordingPage.$static.recordingCourt, [
+          [/[\s\S]*/, '102 Petty France'],
+        ]);
+        await userInterfaceUtils.replaceTextWithinStaticElement(prePortalPages.watchRecordingPage.$static.recordingWitness, [
+          [/[\s\S]*/, 'WitnessOne'],
+        ]);
+        await userInterfaceUtils.replaceTextWithinStaticElement(prePortalPages.watchRecordingPage.$static.recordingDefendants, [
+          [/[\s\S]*/, '{Redacted Name}<br>{Redacted Name}'],
         ]);
         await expect(async () => {
           await expect(prePortalPages.watchRecordingPage.page).toHaveScreenshot('portal-watch-recording-page-visual.png', {

--- a/playwright-e2e/utils/userInterface.utils.ts
+++ b/playwright-e2e/utils/userInterface.utils.ts
@@ -107,7 +107,11 @@ export class UserInterfaceUtils {
     }, replacements);
 
     for (const [, replacement] of replacements) {
-      await expect(locator).toContainText(replacement);
+      if (replacement.includes('<')) {
+        await expect(locator).toContainText(replacement.replace(/<[^>]+>/g, ''));
+      } else {
+        await expect(locator).toContainText(replacement);
+      }
     }
   }
 

--- a/test-catalogue/pre-portal/test-catalogue-accessibility.md
+++ b/test-catalogue/pre-portal/test-catalogue-accessibility.md
@@ -7,5 +7,6 @@
 - Check accessibility on home page
 
 ## Verify accessibility on watch recordings page
+- Create and share a recording for the portal user
 - Navigate to watch recording page
 - Check accessibility on watch recordings page

--- a/test-catalogue/pre-portal/test-catalogue-functional-tests.md
+++ b/test-catalogue/pre-portal/test-catalogue-functional-tests.md
@@ -9,16 +9,18 @@
 - Search for recording by case reference and select option to share
 - Navigate to pre-portal and verify playback of recording is successful
 - Unshare the recording from the portal user within power app
-- Verify portal user is no longer able to access the recording after unsharing
 
 ## Verify details of version 1 existing recording is accurately displayed on pre-portal home page
+- Create and share a recording for the portal user
 - Navigate to pre-portal home page
-- Verify details of case reference (PLAYWRIGHT) are accurately displayed on the home page
+- Verify details of the generated case reference are accurately displayed on the home page
 
 ## Verify user is able to playback version 1 of an existing recording which has been pre assigned to user
-- Navigate to pre-portal home page and select case reference (PLAYWRIGHT)
+- Create and share a recording for the portal user
+- Navigate to pre-portal home page and select the generated case reference
 - Verify playback of recording is successful
 
 ## Verify recording details are accurately displayed on pre-portal watch recordings page for version 1 of an existing recording
-- Navigate to pre-portal home page and select case reference (PLAYWRIGHT)
+- Create and share a recording for the portal user
+- Navigate to pre-portal home page and select the generated case reference
 - Verify recording details are displayed accurately

--- a/test-catalogue/pre-portal/test-catalogue-helpers.md
+++ b/test-catalogue/pre-portal/test-catalogue-helpers.md
@@ -1,0 +1,2 @@
+# helpers catalogue
+

--- a/test-catalogue/pre-portal/test-catalogue-visual-tests.md
+++ b/test-catalogue/pre-portal/test-catalogue-visual-tests.md
@@ -9,5 +9,6 @@
 - Verify portal home page is visually correct
 
 ## Verify watch recording page is visually correct
+- Create and share a recording for the portal user
 - Navigate to watch recording page
 - Verify watch recording page is visually correct

--- a/test-catalogue/pre-power-app/test-catalogue-functional-tests.md
+++ b/test-catalogue/pre-power-app/test-catalogue-functional-tests.md
@@ -1,7 +1,7 @@
 # functional-tests catalogue
 
 ----------------------------------------------------------------------------------------------------
-** File:** `playwright-e2e/tests/pre-power-app/functional-tests/admin/add-user-functional.spec.ts`
+** File:** `playwright-e2e/tests/pre-power-app/functional-tests/Admin/add-user-functional.spec.ts`
 
 ## Verify user is able to click on Add user button and see add user form
 - Pre-requisite step click on Add user button
@@ -10,7 +10,7 @@
 
 
 ----------------------------------------------------------------------------------------------------
-** File:** `playwright-e2e/tests/pre-power-app/functional-tests/admin/manage-cases-functional.spec.ts`
+** File:** `playwright-e2e/tests/pre-power-app/functional-tests/Admin/manage-cases-functional.spec.ts`
 
 ## Verify user is able to search for an existing case and delete the case successfully
 - Pre-requisite step create a new case using api
@@ -20,7 +20,7 @@
 
 
 ----------------------------------------------------------------------------------------------------
-** File:** `playwright-e2e/tests/pre-power-app/functional-tests/admin/manage-court-access-functional.spec.ts`
+** File:** `playwright-e2e/tests/pre-power-app/functional-tests/Admin/manage-court-access-functional.spec.ts`
 
 ## Verify user is able to click on Manage Court Access button and see the deatails
 - Pre-requisite step click on Manage Court Access button
@@ -29,7 +29,7 @@
 
 
 ----------------------------------------------------------------------------------------------------
-** File:** `playwright-e2e/tests/pre-power-app/functional-tests/admin/manage-recording-functional.spec.ts`
+** File:** `playwright-e2e/tests/pre-power-app/functional-tests/Admin/manage-recording-functional.spec.ts`
 
 ## Verify user is able to view recordings on manage recordings page
 - Pre-requisite step click on manage recordings button
@@ -37,7 +37,7 @@
 
 
 ----------------------------------------------------------------------------------------------------
-** File:** `playwright-e2e/tests/pre-power-app/functional-tests/admin/manage-users-functional.spec.ts`
+** File:** `playwright-e2e/tests/pre-power-app/functional-tests/Admin/manage-users-functional.spec.ts`
 
 ## Verify user is able to view Manage Users page and see all three buttons
 - Pre-requisite step verify Manage Users page is visible
@@ -46,7 +46,7 @@
 
 
 ----------------------------------------------------------------------------------------------------
-** File:** `playwright-e2e/tests/pre-power-app/functional-tests/admin/search-user-functional.spec.ts`
+** File:** `playwright-e2e/tests/pre-power-app/functional-tests/Admin/search-user-functional.spec.ts`
 
 ## Verify user is able to click on Search button and see search user form
 - Pre-requisite step click on Search User button


### PR DESCRIPTION
## Summary
- create and share recordings for pre-portal tests instead of relying on stale seeded data
- search by case reference on the portal home page when the app exposes the search field
- redact dynamic recording details and generated test catalogue updates

## Testing
- yarn lint

Full E2E was not run locally because it depends on the deployed PRE environment and secrets.